### PR TITLE
Fix `defpackage` usage

### DIFF
--- a/file-finder.asd
+++ b/file-finder.asd
@@ -1,8 +1,6 @@
 #-asdf3.1 (warning "`fof' used to require ASDF 3.1, after our update of <2024-04-23> that may not be the case anymore.")
 ;; <2024-04-23> After simplification and removal of inferred system, does this hold?
 
-(in-package #:asdf-user)
-
 (defsystem "file-finder"
   :version "0.2.0"
   :author "Pierre Neidhardt <mail@ambrevar.xyz>"
@@ -10,16 +8,12 @@
   :homepage "https://github.com/lisp-maintainers/file-finder"
   :licence "GPL3+"
   :description "File finder. Enable rapid file search, inspection and manipulation."
-  ;; :class :package-inferred-system
-  :depends-on (;; "fof/package"
-	       "named-readtables"
-               "alexandria"
-               "serapeum"
-               "local-time"
-               "file-attributes"
-               "str")
-
+  :depends-on (:named-readtables
+               :alexandria
+               :serapeum
+               :local-time
+               :file-attributes
+               :str)
   :components ((:file "package")
                (:file "file")
-               (:file "predicates")
-               ))
+               (:file "predicates")))

--- a/package.lisp
+++ b/package.lisp
@@ -1,5 +1,4 @@
-
-(uiop:define-package file-finder
+(defpackage file-finder
   (:documentation "File object finder, one package for the two project files (file class, finder predicates).")
   (:use #:common-lisp)
   (:import-from #:serapeum


### PR DESCRIPTION
Otherwise SBCL was failing to compile it. This is a direct dependency of CIEL.

cc @vindarel 